### PR TITLE
GH-11: Add periodic table update functionality with repository tests

### DIFF
--- a/scripts/docker/setup-local-s3.sh
+++ b/scripts/docker/setup-local-s3.sh
@@ -3,4 +3,8 @@ set -ex
 aws --endpoint-url http://localhost:4566 s3api create-bucket \
   --bucket elsevier-technical-exercise \
   --create-bucket-configuration LocationConstraint=eu-west-2
-aws --endpoint-url http://localhost:4566 s3 cp /tmp/periodic_table.json s3://elsevier-technical-exercise/periodic_table.json
+aws --endpoint-url http://localhost:4566 s3api put-bucket-versioning \
+  --bucket elsevier-technical-exercise \
+  --versioning-configuration Status=Enabled
+aws --endpoint-url http://localhost:4566 s3 cp \
+  /tmp/periodic_table.json s3://elsevier-technical-exercise/periodic_table.json

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ElementController.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ElementController.java
@@ -3,8 +3,13 @@ package com.elsevier.technicalexercise.periodictable;
 import com.elsevier.technicalexercise.api.SuccessResponseDto;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -58,5 +63,16 @@ class ElementController {
     return this.periodicTableService.getElement(atomicNumber)
         .thenApply(ElementDetailDto::fromElement)
         .thenApply(SuccessResponseDto::fromSingleItem);
+  }
+
+  @PatchMapping("/elements")
+  @ResponseBody
+  public CompletableFuture<ResponseEntity<?>> updatePeriodicTable(
+      @RequestBody List<PatchElementDto> patchElements) {
+    return this.periodicTableService.updatePeriodicTable(patchElements).thenApply((resp) -> {
+      HttpHeaders headers = new HttpHeaders();
+      headers.add("ETag", resp.etag());
+      return new ResponseEntity<>(null, headers, HttpStatus.NO_CONTENT);
+    });
   }
 }

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/PatchElementDto.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/PatchElementDto.java
@@ -1,0 +1,12 @@
+package com.elsevier.technicalexercise.periodictable;
+
+/**
+ * Data Transfer Object for PATCH operations on periodic table elements.
+ * Contains the fields that can be updated for an element.
+ */
+public record PatchElementDto(
+    String name,
+    int atomicNumber,
+    String alternativeName,
+    String groupBlock) {
+}

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/PeriodicTableEntity.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/PeriodicTableEntity.java
@@ -1,0 +1,13 @@
+package com.elsevier.technicalexercise.periodictable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Entity representing the periodic table data.
+ * Contains a list of element data and an etag for versioning.
+ */
+public record PeriodicTableEntity(
+    List<Map<String, Object>> data,
+    String etag) {
+}

--- a/src/test/java/com/elsevier/technicalexercise/cloud/ObjectStorageTest.java
+++ b/src/test/java/com/elsevier/technicalexercise/cloud/ObjectStorageTest.java
@@ -13,89 +13,200 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith(MockitoExtension.class)
 class ObjectStorageTest {
 
-    private final ObjectStorage objectStorage = new ObjectStorage();
+  private final ObjectStorage objectStorage = new ObjectStorage();
 
-    private static final String BUCKET_NAME = "elsevier-technical-exercise";
-    private static final String KEY_NAME = "periodic_table.json";
+  private static final String BUCKET_NAME = "elsevier-technical-exercise";
+  private static final String KEY_NAME = "periodic_table.json";
 
-    @Test
-    void testGetObject() throws ExecutionException, InterruptedException {
-        // When
-        CompletableFuture<ObjectStorage.GetObjectResponse> futureResponse = objectStorage.getObject(BUCKET_NAME,
-                KEY_NAME);
+  @Test
+  void testGetObject() throws ExecutionException, InterruptedException {
+    // When
+    CompletableFuture<ObjectStorage.GetObjectResponse> futureResponse =
+        objectStorage.getObject(BUCKET_NAME,
+            KEY_NAME);
 
-        // Then
-        assertNotNull(futureResponse,
-                "Future response should not be null");
+    // Then
+    assertNotNull(futureResponse,
+        "Future response should not be null");
 
-        ObjectStorage.GetObjectResponse response = futureResponse.get();
-        assertNotNull(response,
-                "Response should not be null");
-        assertNotNull(response.content(),
-                "Content should not be null");
-        assertTrue(response.content().length > 0,
-                "Content should not be empty");
-        assertNotNull(response.etag(),
-                "ETag should not be null");
+    ObjectStorage.GetObjectResponse response = futureResponse.get();
+    assertNotNull(response,
+        "Response should not be null");
+    assertNotNull(response.content(),
+        "Content should not be null");
+    assertTrue(response.content().length > 0,
+        "Content should not be empty");
+    assertNotNull(response.etag(),
+        "ETag should not be null");
 
-        // Convert content to string and verify it contains expected data
-        String content = new String(response.content(),
-                StandardCharsets.UTF_8);
-        assertTrue(content.contains("\"name\": \"Hydrogen\""),
-                "Content should contain Hydrogen element");
-        assertTrue(content.contains("\"symbol\": \"H\""),
-                "Content should contain H symbol");
-    }
+    // Convert content to string and verify it contains expected data
+    String content = new String(response.content(),
+        StandardCharsets.UTF_8);
+    assertTrue(content.contains("\"name\": \"Hydrogen\""),
+        "Content should contain Hydrogen element");
+    assertTrue(content.contains("\"symbol\": \"H\""),
+        "Content should contain H symbol");
+  }
 
-    @Test
-    void testGetObjectWithInvalidBucket() {
-        // When
-        CompletableFuture<ObjectStorage.GetObjectResponse> futureResponse = objectStorage.getObject("invalid-bucket",
-                KEY_NAME);
+  @Test
+  void testGetObjectWithInvalidBucket() {
+    // When
+    CompletableFuture<ObjectStorage.GetObjectResponse> futureResponse =
+        objectStorage.getObject("invalid-bucket",
+            KEY_NAME);
 
-        // Then
-        assertNotNull(futureResponse,
-                "Future response should not be null");
+    // Then
+    assertNotNull(futureResponse,
+        "Future response should not be null");
 
-        // The future should complete exceptionally
-        Exception exception = assertThrows(ExecutionException.class,
-                () -> {
-                    futureResponse.get();
-                });
+    // The future should complete exceptionally
+    Exception exception = assertThrows(ExecutionException.class,
+        () -> {
+          futureResponse.get();
+        });
 
-        // Verify the exception is related to NoSuchBucket
-        assertTrue(exception.getCause()
-                        .getMessage()
-                        .contains("NoSuchBucket")
-                        || exception.getCause()
-                        .getMessage()
-                        .contains("The specified bucket does not exist"),
-                "Exception should be related to NoSuchBucket");
-    }
+    // Verify the exception is related to NoSuchBucket
+    assertTrue(exception.getCause()
+            .getMessage()
+            .contains("NoSuchBucket")
+            || exception.getCause()
+            .getMessage()
+            .contains("The specified bucket does not exist"),
+        "Exception should be related to NoSuchBucket");
+  }
 
-    @Test
-    void testGetObjectWithInvalidKey() {
-        // When
-        CompletableFuture<ObjectStorage.GetObjectResponse> futureResponse = objectStorage.getObject(BUCKET_NAME,
-                "invalid-key.json");
+  @Test
+  void testGetObjectWithInvalidKey() {
+    // When
+    CompletableFuture<ObjectStorage.GetObjectResponse> futureResponse =
+        objectStorage.getObject(BUCKET_NAME,
+            "invalid-key.json");
 
-        // Then
-        assertNotNull(futureResponse,
-                "Future response should not be null");
+    // Then
+    assertNotNull(futureResponse,
+        "Future response should not be null");
 
-        // The future should complete exceptionally
-        Exception exception = assertThrows(ExecutionException.class,
-                () -> {
-                    futureResponse.get();
-                });
+    // The future should complete exceptionally
+    Exception exception = assertThrows(ExecutionException.class,
+        () -> {
+          futureResponse.get();
+        });
 
-        // Verify the exception is related to NoSuchKey
-        assertTrue(exception.getCause()
-                        .getMessage()
-                        .contains("NoSuchKey")
-                        || exception.getCause()
-                        .getMessage()
-                        .contains("The specified key does not exist"),
-                "Exception should be related to NoSuchKey");
-    }
+    // Verify the exception is related to NoSuchKey
+    assertTrue(exception.getCause()
+            .getMessage()
+            .contains("NoSuchKey")
+            || exception.getCause()
+            .getMessage()
+            .contains("The specified key does not exist"),
+        "Exception should be related to NoSuchKey");
+  }
+
+  @Test
+  void testReplaceObject() throws ExecutionException, InterruptedException {
+    String TEST_KEY_NAME = "tests/test-replace-object.json";
+    objectStorage.copyObject(BUCKET_NAME, KEY_NAME, TEST_KEY_NAME).join();
+    // First, get the object to obtain its etag
+    CompletableFuture<ObjectStorage.GetObjectResponse> getResponse =
+        objectStorage.getObject(BUCKET_NAME, TEST_KEY_NAME);
+
+
+    ObjectStorage.GetObjectResponse originalObject = getResponse.get();
+    String etag = originalObject.etag();
+
+    // Modify the content
+    String originalContent = new String(originalObject.content(), StandardCharsets.UTF_8);
+    String modifiedContent = originalContent.replace("Hydrogen", "Modified Hydrogen");
+    byte[] modifiedBytes = modifiedContent.getBytes(StandardCharsets.UTF_8);
+
+
+    // When: Replace the object
+    CompletableFuture<?> replaceResponse =
+        objectStorage.replaceObject(BUCKET_NAME, TEST_KEY_NAME, modifiedBytes, etag);
+
+    // Then: Verify the replace operation completed successfully
+    assertNotNull(replaceResponse, "Replace response should not be null");
+    replaceResponse.get(); // This will throw an exception if the operation failed
+
+    // Verify the object was actually replaced by getting it again
+    CompletableFuture<ObjectStorage.GetObjectResponse> verifyResponse =
+        objectStorage.getObject(BUCKET_NAME, TEST_KEY_NAME);
+    ObjectStorage.GetObjectResponse updatedObject = verifyResponse.get();
+
+    String updatedContent = new String(updatedObject.content(), StandardCharsets.UTF_8);
+    assertTrue(updatedContent.contains("Modified Hydrogen"),
+        "Updated content should contain the modified text");
+    assertNotEquals(etag, updatedObject.etag(),
+        "ETag should be different after replacement");
+    objectStorage.deleteObject(BUCKET_NAME, TEST_KEY_NAME).join();
+  }
+
+  @Test
+  void testReplaceObjectWithInvalidEtag() {
+    // When: Try to replace an object with an invalid etag
+    String invalidEtag = "\"invalid-etag\"";
+    byte[] content = "Test content".getBytes(StandardCharsets.UTF_8);
+    CompletableFuture<?> replaceResponse =
+        objectStorage.replaceObject(BUCKET_NAME, KEY_NAME, content, invalidEtag);
+
+    // Then: The operation should fail with a precondition failed exception
+    assertNotNull(replaceResponse, "Replace response should not be null");
+    Exception exception = assertThrows(ExecutionException.class, () -> {
+      replaceResponse.get();
+    });
+
+    // Print the actual exception message for debugging
+    System.out.println("[DEBUG_LOG] Exception message: " + exception.getCause().getMessage());
+
+    // Check for various possible error messages related to ETag mismatch
+    assertTrue(exception.getCause().getMessage().contains("PreconditionFailed")
+            || exception.getCause().getMessage().contains("precondition failed")
+            || exception.getCause().getMessage().contains("Precondition Failed")
+            || exception.getCause().getMessage().contains("condition not met")
+            || exception.getCause().getMessage().contains("Condition not met")
+            || exception.getCause().getMessage().contains("ETag")
+            || exception.getCause().getMessage().contains("etag")
+            || exception.getCause().getMessage().contains("pre-conditions")
+            || exception.getCause().getMessage().contains("Status Code: 412"),
+        "Exception should be related to precondition failure due to ETag mismatch");
+  }
+
+  @Test
+  void testReplaceObjectWithInvalidBucket() {
+    // When: Try to replace an object in a non-existent bucket
+    byte[] content = "Test content".getBytes(StandardCharsets.UTF_8);
+    CompletableFuture<?> replaceResponse =
+        objectStorage.replaceObject("invalid-bucket", KEY_NAME, content, "\"some-etag\"");
+
+    // Then: The operation should fail with a no such bucket exception
+    assertNotNull(replaceResponse, "Replace response should not be null");
+    Exception exception = assertThrows(ExecutionException.class, () -> {
+      replaceResponse.get();
+    });
+
+    assertTrue(exception.getCause().getMessage().contains("NoSuchBucket")
+            || exception.getCause().getMessage().contains("The specified bucket does not exist"),
+        "Exception should be related to NoSuchBucket");
+  }
+
+  @Test
+  void testReplaceObjectWithNonExistentKey() {
+    // When: Try to replace a non-existent object
+    byte[] content = "Test content".getBytes(StandardCharsets.UTF_8);
+    CompletableFuture<?> replaceResponse =
+        objectStorage.replaceObject(BUCKET_NAME, "non-existent-key.json", content, "\"some-etag\"");
+
+    // Then: The operation should fail with a not found exception
+    assertNotNull(replaceResponse, "Replace response should not be null");
+    Exception exception = assertThrows(ExecutionException.class, () -> {
+      replaceResponse.get();
+    });
+
+    // The error could be either NoSuchKey or PreconditionFailed depending on the S3 implementation
+    assertTrue(exception.getCause().getMessage().contains("NoSuchKey")
+            || exception.getCause().getMessage().contains("The specified key does not exist")
+            || exception.getCause().getMessage().contains("PreconditionFailed")
+            || exception.getCause().getMessage().contains("precondition failed"),
+        "Exception should be related to the key not existing or precondition failure");
+  }
 }

--- a/src/test/java/com/elsevier/technicalexercise/periodictable/PeriodicTableServiceTest.java
+++ b/src/test/java/com/elsevier/technicalexercise/periodictable/PeriodicTableServiceTest.java
@@ -1,0 +1,171 @@
+package com.elsevier.technicalexercise.periodictable;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class PeriodicTableServiceTest {
+
+  @Mock
+  private PeriodicTableRepository periodicTableRepository;
+
+  private PeriodicTableService periodicTableService;
+
+  @BeforeEach
+  void setUp() {
+    periodicTableService = new PeriodicTableService(periodicTableRepository);
+  }
+
+  @Test
+  void testUpdatePeriodicTable_SuccessfulUpdate() throws ExecutionException, InterruptedException {
+    // Given
+    List<Map<String, Object>> originalData = new ArrayList<>();
+    Map<String, Object> hydrogen = new HashMap<>();
+    hydrogen.put("atomic_number", 1);
+    hydrogen.put("name", "Hydrogen");
+    hydrogen.put("alternative_name", "n/a");
+    hydrogen.put("group_block", "group 1, s-block");
+    originalData.add(hydrogen);
+
+    Map<String, Object> helium = new HashMap<>();
+    helium.put("atomic_number", 2);
+    helium.put("name", "Helium");
+    helium.put("alternative_name", "n/a");
+    helium.put("group_block", "group 18 (noble gases), s-block");
+    originalData.add(helium);
+
+    PeriodicTableEntity originalEntity = new PeriodicTableEntity(originalData, "mockETag");
+
+    // Mock repository behavior
+    when(periodicTableRepository.getPeriodicTable())
+        .thenReturn(CompletableFuture.completedFuture(originalEntity));
+    when(periodicTableRepository.updatePeriodicTable(any(PeriodicTableEntity.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // Create patch elements
+    List<PatchElementDto> patchElements = new ArrayList<>();
+    patchElements.add(new PatchElementDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
+
+    // When
+    CompletableFuture<PeriodicTableEntity> result =
+        periodicTableService.updatePeriodicTable(patchElements);
+
+    // Then
+    assertNotNull(result, "Result should not be null");
+    PeriodicTableEntity updatedEntity = result.get(); // Wait for completion
+
+    // Verify repository methods were called
+    verify(periodicTableRepository).getPeriodicTable();
+    verify(periodicTableRepository).updatePeriodicTable(any(PeriodicTableEntity.class));
+
+    // Capture the argument passed to updatePeriodicTable
+    var argumentCaptor = org.mockito.ArgumentCaptor.forClass(PeriodicTableEntity.class);
+    verify(periodicTableRepository).updatePeriodicTable(argumentCaptor.capture());
+
+
+    // Verify the updated entity contains the expected changes
+    assertEquals(2, updatedEntity.data().size(), "Should still have 2 elements");
+
+    Map<String, Object> updatedHydrogen = updatedEntity.data().getFirst();
+    assertEquals("Updated Hydrogen", updatedHydrogen.get("name"), "Name should be updated");
+    assertEquals("H", updatedHydrogen.get("alternative_name"),
+        "Alternative name should be updated");
+    assertEquals("updated group 1, s-block", updatedHydrogen.get("group_block"),
+        "Group block should be updated");
+
+    Map<String, Object> unchangedHelium = updatedEntity.data().get(1);
+    assertEquals("Helium", unchangedHelium.get("name"), "Helium should remain unchanged");
+  }
+
+  @Test
+  void testUpdatePeriodicTable_GetPeriodicTableFails() {
+    // Given
+    RuntimeException expectedException = new RuntimeException("Failed to get periodic table");
+
+    // Mock repository behavior to fail when getting the periodic table
+    when(periodicTableRepository.getPeriodicTable())
+        .thenReturn(CompletableFuture.failedFuture(expectedException));
+
+    // Create patch elements
+    List<PatchElementDto> patchElements = new ArrayList<>();
+    patchElements.add(new PatchElementDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
+
+    // When
+    CompletableFuture<PeriodicTableEntity> result = 
+        periodicTableService.updatePeriodicTable(patchElements);
+
+    // Then
+    // Verify the future completes exceptionally with the expected exception
+    ExecutionException executionException = assertThrows(
+        ExecutionException.class, 
+        () -> result.get(),
+        "Should throw ExecutionException when getPeriodicTable fails"
+    );
+
+    assertEquals(expectedException, executionException.getCause(), 
+        "Exception cause should match the expected exception");
+
+    // Verify repository methods were called
+    verify(periodicTableRepository).getPeriodicTable();
+    verify(periodicTableRepository, never()).updatePeriodicTable(any(PeriodicTableEntity.class));
+  }
+
+  @Test
+  void testUpdatePeriodicTable_UpdatePeriodicTableFails() {
+    // Given
+    List<Map<String, Object>> originalData = new ArrayList<>();
+    Map<String, Object> hydrogen = new HashMap<>();
+    hydrogen.put("atomic_number", 1);
+    hydrogen.put("name", "Hydrogen");
+    hydrogen.put("alternative_name", "n/a");
+    hydrogen.put("group_block", "group 1, s-block");
+    originalData.add(hydrogen);
+
+    PeriodicTableEntity originalEntity = new PeriodicTableEntity(originalData, "mockETag");
+    RuntimeException expectedException = new RuntimeException("Failed to update periodic table");
+
+    // Mock repository behavior
+    when(periodicTableRepository.getPeriodicTable())
+        .thenReturn(CompletableFuture.completedFuture(originalEntity));
+    when(periodicTableRepository.updatePeriodicTable(any(PeriodicTableEntity.class)))
+        .thenReturn(CompletableFuture.failedFuture(expectedException));
+
+    // Create patch elements
+    List<PatchElementDto> patchElements = new ArrayList<>();
+    patchElements.add(new PatchElementDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
+
+    // When
+    CompletableFuture<PeriodicTableEntity> result = 
+        periodicTableService.updatePeriodicTable(patchElements);
+
+    // Then
+    // Verify the future completes exceptionally with the expected exception
+    ExecutionException executionException = assertThrows(
+        ExecutionException.class, 
+        () -> result.get(),
+        "Should throw ExecutionException when updatePeriodicTable fails"
+    );
+
+    assertEquals(expectedException, executionException.getCause(), 
+        "Exception cause should match the expected exception");
+
+    // Verify repository methods were called
+    verify(periodicTableRepository).getPeriodicTable();
+    verify(periodicTableRepository).updatePeriodicTable(any(PeriodicTableEntity.class));
+  }
+}


### PR DESCRIPTION
this close #11
Introduce functionality to update the periodic table via PATCH, including merging element updates with existing data. Add extensive unit tests for both the service and repository layers to validate correct behavior for success and failure scenarios. Also, improve object storage implementation with support for replace, copy, and delete operations with tests.