### PR TITLE
GH-24: Add JaCoCo Maven plugin for code coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,25 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.13</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>3.6.0</version>


### PR DESCRIPTION
this close #24
Integrated the JaCoCo Maven plugin to generate code coverage reports. This includes configuring the plugin with `prepare-agent` and `report` goals for execution during tests. This change helps monitor and improve code quality through coverage analysis.