### PR TITLE
GH-32: Refactor DTOs and add validation for group and group block

### DIFF
--- a/src/main/java/com/elsevier/technicalexercise/api/GlobalExceptionControllerHandler.java
+++ b/src/main/java/com/elsevier/technicalexercise/api/GlobalExceptionControllerHandler.java
@@ -28,6 +28,7 @@ public class GlobalExceptionControllerHandler {
    * @return ResponseEntity containing the error response
    */
   @ExceptionHandler(ErrorResponseException.class)
+  @ResponseBody
   public ResponseEntity<ErrorResponseDto> handleErrorResponseException(ErrorResponseException ex) {
     return new ResponseEntity<>(ErrorResponseDto.fromException(
         HttpStatus.valueOf(ex.getStatusCode().value()),
@@ -61,7 +62,7 @@ public class GlobalExceptionControllerHandler {
   /**
    * Handles exceptions for malformed HTTP message bodies.
    *
-   * @param ex The HttpMessageNotReadableException to handle
+   * @param ex      The HttpMessageNotReadableException to handle
    * @param request The current web request
    * @return ErrorResponseDto with information about the malformed request
    */
@@ -83,7 +84,7 @@ public class GlobalExceptionControllerHandler {
   /**
    * Handles exceptions for method argument type mismatches.
    *
-   * @param ex The MethodArgumentTypeMismatchException to handle
+   * @param ex      The MethodArgumentTypeMismatchException to handle
    * @param request The current web request
    * @return ErrorResponseDto with information about the type mismatch
    */
@@ -132,7 +133,7 @@ public class GlobalExceptionControllerHandler {
   /**
    * Handles exceptions for resources not found.
    *
-   * @param ex The NoResourceFoundException to handle
+   * @param ex      The NoResourceFoundException to handle
    * @param request The current web request
    * @return ErrorResponseDto with information about the not found resource
    */

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ElementListingRequestDto.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ElementListingRequestDto.java
@@ -1,0 +1,27 @@
+package com.elsevier.technicalexercise.periodictable;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+/**
+ * Data Transfer Object for element listing requests.
+ * Contains filtering parameters for querying periodic table elements.
+ */
+public class ElementListingRequestDto {
+  @Parameter(
+      description = "The periodic table group to filter by."
+          + "Valid values are 1 to 18 (inclusive) or 'n/a'.",
+      example = "2"
+  )
+  @ValidGroup
+  private String group;
+
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+
+}

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ElementPatchRequestDto.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ElementPatchRequestDto.java
@@ -1,5 +1,7 @@
 package com.elsevier.technicalexercise.periodictable;
 
+import com.elsevier.technicalexercise.utils.Validator;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
@@ -7,7 +9,7 @@ import jakarta.validation.constraints.Positive;
  * Data Transfer Object for PATCH operations on periodic table elements.
  * Contains the fields that can be updated for an element.
  */
-public class PatchElementDto {
+public class ElementPatchRequestDto {
 
   private String name;
 
@@ -17,24 +19,25 @@ public class PatchElementDto {
 
   private String alternativeName;
 
+  @ValidGroupBlock
   private String groupBlock;
 
   /**
    * No-argument constructor for frameworks.
    */
-  public PatchElementDto() {
+  public ElementPatchRequestDto() {
   }
 
   /**
    * All-arguments constructor for convenience (e.g., tests).
    *
-   * @param name The name of the element
-   * @param atomicNumber The atomic number of the element
+   * @param name            The name of the element
+   * @param atomicNumber    The atomic number of the element
    * @param alternativeName The alternative name of the element
-   * @param groupBlock The group block of the element
+   * @param groupBlock      The group block of the element
    */
-  public PatchElementDto(String name, Integer atomicNumber, String alternativeName,
-                         String groupBlock) {
+  public ElementPatchRequestDto(String name, Integer atomicNumber, String alternativeName,
+                                String groupBlock) {
     this.name = name;
     this.atomicNumber = atomicNumber;
     this.alternativeName = alternativeName;
@@ -73,5 +76,12 @@ public class PatchElementDto {
 
   public void setGroupBlock(String groupBlock) {
     this.groupBlock = groupBlock;
+  }
+
+  @Schema(hidden = true)
+  public boolean isEmpty() {
+    return Validator.isNotNullOrBlank(this.name)
+        && Validator.isNotNullOrBlank(this.alternativeName)
+        && Validator.isNotNullOrBlank(this.groupBlock);
   }
 }

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ElementPatchRequestDto.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ElementPatchRequestDto.java
@@ -80,8 +80,8 @@ public class ElementPatchRequestDto {
 
   @Schema(hidden = true)
   public boolean isEmpty() {
-    return Validator.isNotNullOrBlank(this.name)
-        && Validator.isNotNullOrBlank(this.alternativeName)
-        && Validator.isNotNullOrBlank(this.groupBlock);
+    return Validator.isNullOrBlank(this.name)
+        && Validator.isNullOrBlank(this.alternativeName)
+        && Validator.isNullOrBlank(this.groupBlock);
   }
 }

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/PeriodicTableRepository.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/PeriodicTableRepository.java
@@ -124,8 +124,7 @@ class PeriodicTableRepository {
               try {
                 String[] groups = element.groupBlock().split(",");
                 String groupBlockNumber = groups[0].strip().split(" ")[1];
-                String groupBlock = groups[1].strip();
-                return groupBlockNumber.equals(group) || groupBlock.equals(group);
+                return groupBlockNumber.equals(group);
               } catch (Exception e) {
                 throw new InvalidGroupBlockException(
                     "Invalid group block : " + e.getMessage(), e);

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/PeriodicTableService.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/PeriodicTableService.java
@@ -31,23 +31,12 @@ class PeriodicTableService {
     this.periodicTableRepository = periodicTableRepository;
   }
 
-  /**
-   * Finds all elements in the periodic table.
-   *
-   * @return a future that will complete with the list of elements
-   */
-  public CompletableFuture<List<ElementEntity>> findElements() {
-    return periodicTableRepository.findElements();
-  }
-
-  /**
-   * Finds elements by group.
-   *
-   * @param group the group to filter by
-   * @return a future that will complete with the filtered list of elements
-   */
-  public CompletableFuture<List<ElementEntity>> findElements(String group) {
-    return periodicTableRepository.findElements(group);
+  public CompletableFuture<List<ElementEntity>> findElements(
+      ElementListingRequestDto elementListingRequestDto) {
+    if (elementListingRequestDto.getGroup() == null) {
+      return periodicTableRepository.findElements();
+    }
+    return periodicTableRepository.findElements(elementListingRequestDto.getGroup());
   }
 
   /**
@@ -65,12 +54,12 @@ class PeriodicTableService {
   }
 
   public CompletableFuture<PeriodicTableEntity> updatePeriodicTable(
-      List<PatchElementDto> patchElements) {
+      List<ElementPatchRequestDto> patchElements) {
     return periodicTableRepository.getPeriodicTable()
         .thenApply(
             periodicTableEntity -> new PeriodicTableEntity(
                 periodicTableEntity.data().stream().map(existingElement -> {
-                  PatchElementDto newElementHaveToUpdate =
+                  ElementPatchRequestDto newElementHaveToUpdate =
                       patchElements.stream().filter(newElement -> {
                         return newElement.getAtomicNumber()
                             ==

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ValidGroup.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ValidGroup.java
@@ -1,0 +1,84 @@
+package com.elsevier.technicalexercise.periodictable;
+
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validation annotation for periodic table group numbers.
+ * Validates that a string represents a valid group number (1-18 or "n/a").
+ */
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidGroup.GroupValidator.class)
+public @interface ValidGroup {
+  /**
+   * Error message to be used when the validation fails.
+   *
+   * @return the error message
+   */
+  String message() default "Invalid group number";
+
+  /**
+   * Groups for this constraint.
+   *
+   * @return the groups
+   */
+  Class<?>[] groups() default {};
+
+  /**
+   * Payloads for this constraint.
+   *
+   * @return the payloads
+   */
+  Class<? extends Payload>[] payload() default {};
+
+  /**
+   * Validator implementation for the ValidGroup annotation.
+   * Validates that a string represents a valid group number (1-18 or "n/a").
+   */
+  static class GroupValidator implements ConstraintValidator<ValidGroup, String> {
+    /**
+     * Validates if the given string is a valid group number.
+     *
+     * @param value the group number to validate
+     * @return true if the value is a valid group number, false otherwise
+     */
+    static boolean validateGroup(String value) {
+      if ("n/a".equalsIgnoreCase(value)) {
+        return true;
+      }
+      try {
+        int groupNumber = Integer.parseInt(value);
+        if (groupNumber < 1 || groupNumber > 18) {
+          return false;
+        }
+      } catch (NumberFormatException ex) {
+        return false;
+      }
+      return true;
+    }
+
+    /**
+     * Validates if the given string is a valid group number.
+     *
+     * @param value the group number to validate
+     * @param context the constraint validator context
+     * @return true if the value is a valid group number or null, false otherwise
+     */
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+      if (value == null) {
+        return true;
+      }
+      return GroupValidator.validateGroup(value);
+    }
+  }
+
+}

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ValidGroupBlock.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ValidGroupBlock.java
@@ -1,0 +1,88 @@
+package com.elsevier.technicalexercise.periodictable;
+
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Validation annotation for periodic table group block strings.
+ * Validates that a string represents a valid group block in the format "group X, Y-block"
+ * where X is a valid group number (1-18 or "n/a") and Y is one of "s", "p", "d", "f", or "g".
+ */
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidGroupBlock.GroupBlockValidator.class)
+public @interface ValidGroupBlock {
+  /**
+   * Error message to be used when the validation fails.
+   *
+   * @return the error message
+   */
+  String message() default "Invalid group block";
+
+  /**
+   * Groups for this constraint.
+   *
+   * @return the groups
+   */
+  Class<?>[] groups() default {};
+
+  /**
+   * Payloads for this constraint.
+   *
+   * @return the payloads
+   */
+  Class<? extends Payload>[] payload() default {};
+
+  /**
+   * Validator implementation for the ValidGroupBlock annotation.
+   * Validates that a string represents a valid group block in the format "group X, Y-block".
+   */
+  static class GroupBlockValidator implements ConstraintValidator<ValidGroupBlock, String> {
+    /**
+     * Validates if the given string is a valid group block.
+     *
+     * @param value the group block to validate
+     * @param context the constraint validator context
+     * @return true if the value is a valid group block or null, false otherwise
+     */
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+      if (value == null) {
+        return true;
+      }
+      String[] parts = value.split(",");
+      if (parts.length != 2) {
+        return false;
+      }
+
+      String groupPart = parts[0].trim();
+      String blockPart = parts[1].trim();
+      Pattern pattern =
+          Pattern.compile("^group (n/a|[0-9]{1,2})( \\([a-zA-Z ]+\\))?$", Pattern.CASE_INSENSITIVE);
+      Matcher matcher = pattern.matcher(groupPart);
+
+      if (!matcher.matches()) {
+        return false;
+      }
+      String groupNum = matcher.group(1);
+      if (!ValidGroup.GroupValidator.validateGroup(groupNum)) {
+        return false;
+      }
+
+      if (!blockPart.toLowerCase().matches("^[spdfg]-block$")) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+}

--- a/src/main/java/com/elsevier/technicalexercise/utils/Validator.java
+++ b/src/main/java/com/elsevier/technicalexercise/utils/Validator.java
@@ -14,4 +14,14 @@ public class Validator {
     return value != null && !value.trim().isEmpty();
   }
 
+  /**
+   * Checks if a string is null or blank (contains only whitespace characters or is empty).
+   *
+   * @param value The string to check
+   * @return true if the string is null or contains only whitespace characters
+   */
+  public static boolean isNullOrBlank(String value) {
+    return !Validator.isNotNullOrBlank(value);
+  }
+
 }

--- a/src/test/java/com/elsevier/technicalexercise/periodictable/ElementControllerMutationTest.java
+++ b/src/test/java/com/elsevier/technicalexercise/periodictable/ElementControllerMutationTest.java
@@ -68,9 +68,9 @@ public class ElementControllerMutationTest {
         mockMvc.perform(patch("/elements")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsBytes(List.of(
-                    new PatchElementDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"),
-                    new PatchElementDto("Updated Helium", 2, "He",
-                        "updated group 18 (noble gases), s-block")
+                    new ElementPatchRequestDto("Updated Hydrogen", 1, "H", "group 1, s-block"),
+                    new ElementPatchRequestDto("Updated Helium", 2, "He",
+                        "group 18 (noble gases), s-block")
                 ))))
             .andExpect(request().asyncStarted())
             .andReturn();
@@ -110,7 +110,7 @@ public class ElementControllerMutationTest {
         mockMvc.perform(patch("/elements")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsBytes(List.of(
-                    new PatchElementDto("Only Name Updated", 3, null, null)
+                    new ElementPatchRequestDto("Only Name Updated", 3, null, null)
                 ))))
             .andExpect(request().asyncStarted())
             .andReturn();
@@ -138,7 +138,7 @@ public class ElementControllerMutationTest {
         mockMvc.perform(patch("/elements")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsBytes(List.of(
-                    new PatchElementDto(null, 4, "Updated Be", null)
+                    new ElementPatchRequestDto(null, 4, "Updated Be", null)
                 ))))
             .andExpect(request().asyncStarted())
             .andReturn();
@@ -167,7 +167,7 @@ public class ElementControllerMutationTest {
         mockMvc.perform(patch("/elements")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsBytes(List.of(
-                    new PatchElementDto(null, 5, null, "Updated group block")
+                    new ElementPatchRequestDto(null, 5, null, "group n/a, f-block")
                 ))))
             .andExpect(request().asyncStarted())
             .andReturn();
@@ -191,19 +191,17 @@ public class ElementControllerMutationTest {
   @Test
   public void testPatchNonExistentElement() throws Exception {
     // When - try to update an element with atomic number that doesn't exist
-    MvcResult mvcPatchResult =
         mockMvc.perform(patch("/elements")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsBytes(List.of(
-                    new PatchElementDto("Non-existent Element", 999, "XX", "non-existent group")
+                    new ElementPatchRequestDto("Non-existent Element", 999, "XX", "non-existent group")
                 ))))
-            .andExpect(request().asyncStarted())
-            .andReturn();
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.error.code").value(400))
+            .andExpect(jsonPath("$.error.reason").value("HandlerMethodValidationException"))
+            .andExpect(jsonPath("$.error.message").exists());
 
-    // Then - should still return 204 No Content as the operation is idempotent
-    mockMvc.perform(asyncDispatch(mvcPatchResult))
-        .andExpect(status().isNoContent())
-        .andExpect(header().exists("ETag"));
   }
 
   @Test
@@ -225,7 +223,7 @@ public class ElementControllerMutationTest {
     mockMvc.perform(patch("/elements")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(mapper.writeValueAsBytes(List.of(
-                    new PatchElementDto(null, 1, null, null)
+                    new ElementPatchRequestDto(null, 1, null, null)
                 ))))
             .andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/elsevier/technicalexercise/periodictable/ElementControllerTest.java
+++ b/src/test/java/com/elsevier/technicalexercise/periodictable/ElementControllerTest.java
@@ -56,10 +56,10 @@ public class ElementControllerTest {
   }
 
   @Test
-  public void testFilterByGroupBlock() throws Exception {
+  public void testFilterByGroupNA() throws Exception {
     // When
     MvcResult mvcResult = mockMvc.perform(get("/elements")
-            .param("group", "s-block")
+            .param("group", "n/a")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(request().asyncStarted())
         .andReturn();
@@ -70,25 +70,18 @@ public class ElementControllerTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.data.items").isArray())
         // s-block should have fewer elements than the total
-        .andExpect(jsonPath("$.data.items.length()").value(14));
+        .andExpect(jsonPath("$.data.items.length()").value(30));
   }
 
   @Test
   public void testFilterByNonExistentGroup() throws Exception {
-    // When
-    MvcResult mvcResult = mockMvc.perform(get("/elements")
+    mockMvc.perform(get("/elements")
             .param("group", "non-existent-group")
             .accept(MediaType.APPLICATION_JSON))
-        .andExpect(request().asyncStarted())
-        .andReturn();
+        .andExpect(jsonPath("$.error.code").value(400))
+        .andExpect(jsonPath("$.error.reason").value("MethodArgumentNotValidException"))
+        .andExpect(jsonPath("$.error.message").exists());
 
-    // Then
-    mockMvc.perform(asyncDispatch(mvcResult))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.data.items").isArray())
-        // Non-existent group should return empty array
-        .andExpect(jsonPath("$.data.items.length()").value(0));
   }
 
   @Test

--- a/src/test/java/com/elsevier/technicalexercise/periodictable/PeriodicTableRepositoryTest.java
+++ b/src/test/java/com/elsevier/technicalexercise/periodictable/PeriodicTableRepositoryTest.java
@@ -257,112 +257,6 @@ class PeriodicTableRepositoryTest {
   }
 
   @Test
-  void testFindElementsByBlockType() throws ExecutionException, InterruptedException {
-    // Given
-    String jsonContent = """
-        [
-            {
-                "name": "Hydrogen",
-                "atomic_number": 1,
-                "alternative_name": "n/a",
-                "group_block": "group 1, s-block"
-            },
-            {
-                "name": "Helium",
-                "atomic_number": 2,
-                "alternative_name": "n/a",
-                "group_block": "group 18 (noble gases), s-block"
-            },
-            {
-                "name": "Boron",
-                "atomic_number": 5,
-                "alternative_name": "n/a",
-                "group_block": "group 13, p-block"
-            }
-        ]
-        """;
-
-    ObjectStorage.GetObjectResponse mockResponse = new ObjectStorage.GetObjectResponse(
-        jsonContent.getBytes(StandardCharsets.UTF_8),
-        "mockETag"
-    );
-
-    when(objectStorage.getObject(eq(testBucketName),
-        eq(testObjectKeyPath)))
-        .thenReturn(CompletableFuture.completedFuture(mockResponse));
-
-    // When
-    CompletableFuture<List<ElementEntity>> futureElements =
-        periodicTableRepository.findElements("s-block");
-
-    // Then
-    assertNotNull(futureElements,
-        "Future elements should not be null");
-
-    List<ElementEntity> elements = futureElements.get();
-    assertNotNull(elements,
-        "Elements list should not be null");
-    assertEquals(2, elements.size(),
-        "Should have 2 elements in s-block");
-
-    // Verify that only elements from s-block are returned
-    for (ElementEntity element : elements) {
-      assertTrue(element.groupBlock().contains("s-block"),
-          "Element should be in s-block");
-    }
-
-    // Verify specific elements
-    assertTrue(elements.stream().anyMatch(e -> e.name().equals("Hydrogen")),
-        "Hydrogen should be in the result");
-    assertTrue(elements.stream().anyMatch(e -> e.name().equals("Helium")),
-        "Helium should be in the result");
-    assertFalse(elements.stream().anyMatch(e -> e.name().equals("Boron")),
-        "Boron should not be in the result");
-  }
-
-  @Test
-  void testFindElementsByGroupWithInvalidGroupBlock() {
-    // Given
-    String jsonContent = """
-        [
-            {
-                "name": "InvalidElement",
-                "atomic_number": 999,
-                "alternative_name": "n/a",
-                "group_block": "invalid format"
-            }
-        ]
-        """;
-
-    ObjectStorage.GetObjectResponse mockResponse = new ObjectStorage.GetObjectResponse(
-        jsonContent.getBytes(StandardCharsets.UTF_8),
-        "mockETag"
-    );
-
-    when(objectStorage.getObject(eq(testBucketName),
-        eq(testObjectKeyPath)))
-        .thenReturn(CompletableFuture.completedFuture(mockResponse));
-
-    // When
-    CompletableFuture<List<ElementEntity>> futureElements =
-        periodicTableRepository.findElements("1");
-
-    // Then
-    assertNotNull(futureElements,
-        "Future elements should not be null");
-
-    Exception exception = assertThrows(ExecutionException.class,
-        () -> {
-          futureElements.get();
-        });
-
-    assertTrue(exception.getCause() instanceof RuntimeException,
-        "Should throw a RuntimeException");
-    assertTrue(exception.getCause().getMessage().contains("Invalid group block"),
-        "Should contain error message about invalid group block");
-  }
-
-  @Test
   void testGetElementByAtomicNumber() throws ExecutionException, InterruptedException {
     // Given
     String jsonContent = """
@@ -392,7 +286,8 @@ class PeriodicTableRepositoryTest {
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     // When
-    CompletableFuture<Optional<ElementEntity>> futureElement = periodicTableRepository.getElement(1);
+    CompletableFuture<Optional<ElementEntity>> futureElement =
+        periodicTableRepository.getElement(1);
 
     // Then
     assertNotNull(futureElement,
@@ -443,7 +338,8 @@ class PeriodicTableRepositoryTest {
         .thenReturn(CompletableFuture.completedFuture(mockResponse));
 
     // When
-    CompletableFuture<Optional<ElementEntity>> futureElement = periodicTableRepository.getElement(999);
+    CompletableFuture<Optional<ElementEntity>> futureElement =
+        periodicTableRepository.getElement(999);
 
     // Then
     assertNotNull(futureElement,

--- a/src/test/java/com/elsevier/technicalexercise/periodictable/PeriodicTableServiceTest.java
+++ b/src/test/java/com/elsevier/technicalexercise/periodictable/PeriodicTableServiceTest.java
@@ -58,8 +58,8 @@ class PeriodicTableServiceTest {
         .thenReturn(CompletableFuture.completedFuture(null));
 
     // Create patch elements
-    List<PatchElementDto> patchElements = new ArrayList<>();
-    patchElements.add(new PatchElementDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
+    List<ElementPatchRequestDto> patchElements = new ArrayList<>();
+    patchElements.add(new ElementPatchRequestDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
 
     // When
     CompletableFuture<PeriodicTableEntity> result =
@@ -102,8 +102,8 @@ class PeriodicTableServiceTest {
         .thenReturn(CompletableFuture.failedFuture(expectedException));
 
     // Create patch elements
-    List<PatchElementDto> patchElements = new ArrayList<>();
-    patchElements.add(new PatchElementDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
+    List<ElementPatchRequestDto> patchElements = new ArrayList<>();
+    patchElements.add(new ElementPatchRequestDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
 
     // When
     CompletableFuture<PeriodicTableEntity> result = 
@@ -146,8 +146,8 @@ class PeriodicTableServiceTest {
         .thenReturn(CompletableFuture.failedFuture(expectedException));
 
     // Create patch elements
-    List<PatchElementDto> patchElements = new ArrayList<>();
-    patchElements.add(new PatchElementDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
+    List<ElementPatchRequestDto> patchElements = new ArrayList<>();
+    patchElements.add(new ElementPatchRequestDto("Updated Hydrogen", 1, "H", "updated group 1, s-block"));
 
     // When
     CompletableFuture<PeriodicTableEntity> result = 


### PR DESCRIPTION
this close #32
Replaced PatchElementDto with ElementPatchRequestDto and introduced ElementListingRequestDto for cleaner data transfer. Added @ValidGroup and @ValidGroupBlock annotations to validate periodic table input formats and adjusted related services, controllers, and tests for consistency. Removed obsolete methods and improved error handling for invalid input scenarios.