### PR TITLE
GH-36: Refactor error handling and enhance API request documentation

### DIFF
--- a/src/main/java/com/elsevier/technicalexercise/api/ErrorResponseDto.java
+++ b/src/main/java/com/elsevier/technicalexercise/api/ErrorResponseDto.java
@@ -8,39 +8,39 @@ import org.springframework.http.HttpStatus;
 /**
  * Standard error response DTO for API errors.
  */
-public record ErrorResponseDto(Map<String, Object> error) {
+public record ErrorResponseDto(int code, String message, String reason, List<Error> errors) {
   /**
    * Nested record representing a specific error with reason and message.
    *
-   * @param reason The error reason or type
+   * @param reason  The error reason or type
    * @param message The detailed error message
    */
-  public record Error(String reason, String message) {
+  public record Error(String reason, String message, String location, String locationType) {
   }
 
   /**
    * Creates an error response from an exception.
    *
-   * @param status The HTTP status code
+   * @param status  The HTTP status code
    * @param message The error message
-   * @param ex The exception that caused the error
+   * @param ex      The exception that caused the error
    * @return A new ErrorResponseDto with information from the exception
    */
   public static ErrorResponseDto fromException(HttpStatus status, String message, Exception ex) {
-    Map<String, Object> data = new HashMap<>();
-    data.put("code", status.value());
-    data.put("message", message);
-    data.put("reason", ex.getClass().getSimpleName());
-    data.put("errors", List.of(new Error(ex.getClass().getSimpleName(), ex.getMessage())));
-    return new ErrorResponseDto(data);
+    return new ErrorResponseDto(
+        status.value(),
+        message,
+        ex.getClass().getSimpleName(),
+        List.of(new Error(ex.getClass().getSimpleName(), ex.getMessage(), null, null))
+    );
   }
 
   /**
    * Creates an error response from a list of errors, using the first error's reason.
    *
-   * @param status The HTTP status code
+   * @param status  The HTTP status code
    * @param message The error message
-   * @param errors The list of errors
+   * @param errors  The list of errors
    * @return A new ErrorResponseDto with information from the errors
    */
   public static ErrorResponseDto fromErrors(HttpStatus status, String message, List<Error> errors) {
@@ -50,19 +50,16 @@ public record ErrorResponseDto(Map<String, Object> error) {
   /**
    * Creates an error response from a list of errors with a specified reason.
    *
-   * @param status The HTTP status code
-   * @param reason The error reason
+   * @param status  The HTTP status code
+   * @param reason  The error reason
    * @param message The error message
-   * @param errors The list of errors
+   * @param errors  The list of errors
    * @return A new ErrorResponseDto with the provided information
    */
   public static ErrorResponseDto fromErrors(HttpStatus status, String reason, String message,
                                             List<Error> errors) {
-    Map<String, Object> data = new HashMap<>();
-    data.put("code", status.value());
-    data.put("message", message);
-    data.put("reason", reason);
-    data.put("errors", errors);
-    return new ErrorResponseDto(data);
+    return new ErrorResponseDto(status.value(),
+        message,
+        reason, errors);
   }
 }

--- a/src/main/java/com/elsevier/technicalexercise/api/ErrorResponseDto.java
+++ b/src/main/java/com/elsevier/technicalexercise/api/ErrorResponseDto.java
@@ -8,58 +8,100 @@ import org.springframework.http.HttpStatus;
 /**
  * Standard error response DTO for API errors.
  */
-public record ErrorResponseDto(int code, String message, String reason, List<Error> errors) {
+public record ErrorResponseDto(Error error) {
   /**
-   * Nested record representing a specific error with reason and message.
+   * Represents the error details in the API response.
    *
-   * @param reason  The error reason or type
-   * @param message The detailed error message
+   * @param code HTTP status code
+   * @param message Error message
+   * @param reason Error reason
+   * @param errors List of detailed error information
    */
-  public record Error(String reason, String message, String location, String locationType) {
+  public record Error(int code, String message, String reason, List<ErrorDetail> errors) {
   }
+
+  /**
+   * Represents detailed information about a specific error.
+   *
+   * @param reason The reason for the error
+   * @param message The error message
+   * @param location The location where the error occurred (can be null)
+   * @param locationType The type of location (can be null)
+   */
+  public record ErrorDetail(String reason, String message, String location, String locationType) {
+    static ErrorDetail fromException(Exception ex) {
+      return fromException(ex, ex.getMessage());
+    }
+
+    static ErrorDetail fromException(String reason, String message) {
+      return new ErrorDetail(reason, message, null, null);
+    }
+
+    static ErrorDetail fromException(Exception ex, String message) {
+      return fromException(
+          ex.getClass().getSimpleName(),
+          message
+      );
+    }
+  }
+
 
   /**
    * Creates an error response from an exception.
    *
-   * @param status  The HTTP status code
-   * @param message The error message
-   * @param ex      The exception that caused the error
-   * @return A new ErrorResponseDto with information from the exception
+   * @param status The HTTP status code to use in the response
+   * @param ex The exception that caused the error
+   * @return A new ErrorResponseDto containing the exception details
    */
-  public static ErrorResponseDto fromException(HttpStatus status, String message, Exception ex) {
+  public static ErrorResponseDto fromException(HttpStatus status, Exception ex) {
     return new ErrorResponseDto(
-        status.value(),
-        message,
-        ex.getClass().getSimpleName(),
-        List.of(new Error(ex.getClass().getSimpleName(), ex.getMessage(), null, null))
+        new Error(status.value(),
+            ex.getMessage(),
+            ex.getClass().getSimpleName(),
+            List.of(new ErrorDetail(ex.getClass().getSimpleName(), ex.getMessage(), null, null))
+        )
     );
   }
 
   /**
-   * Creates an error response from a list of errors, using the first error's reason.
+   * Creates an error response from a list of error details.
    *
-   * @param status  The HTTP status code
-   * @param message The error message
-   * @param errors  The list of errors
-   * @return A new ErrorResponseDto with information from the errors
+   * @param status The HTTP status code to use in the response
+   * @param errors The list of error details
+   * @return A new ErrorResponseDto containing the error details
    */
-  public static ErrorResponseDto fromErrors(HttpStatus status, String message, List<Error> errors) {
+  public static ErrorResponseDto fromErrors(HttpStatus status, List<ErrorDetail> errors) {
+    ErrorDetail firstError = errors.getFirst();
+    return fromErrors(status, firstError.reason(), firstError.message(), errors);
+  }
+
+
+  /**
+   * Creates an error response with a custom message from a list of error details.
+   *
+   * @param status The HTTP status code to use in the response
+   * @param message The custom error message
+   * @param errors The list of error details
+   * @return A new ErrorResponseDto containing the error details with the custom message
+   */
+  public static ErrorResponseDto fromErrors(HttpStatus status, String message,
+                                            List<ErrorDetail> errors) {
     return fromErrors(status, errors.getFirst().reason(), message, errors);
   }
 
   /**
-   * Creates an error response from a list of errors with a specified reason.
+   * Creates an error response with custom reason and message from a list of error details.
    *
-   * @param status  The HTTP status code
-   * @param reason  The error reason
-   * @param message The error message
-   * @param errors  The list of errors
-   * @return A new ErrorResponseDto with the provided information
+   * @param status The HTTP status code to use in the response
+   * @param reason The custom error reason
+   * @param message The custom error message
+   * @param errors The list of error details
+   * @return A new ErrorResponseDto containing the error details with custom reason and message
    */
   public static ErrorResponseDto fromErrors(HttpStatus status, String reason, String message,
-                                            List<Error> errors) {
-    return new ErrorResponseDto(status.value(),
+                                            List<ErrorDetail> errors) {
+    return new ErrorResponseDto(new Error(status.value(),
         message,
-        reason, errors);
+        reason, errors));
   }
 }

--- a/src/main/java/com/elsevier/technicalexercise/api/GlobalExceptionControllerHandler.java
+++ b/src/main/java/com/elsevier/technicalexercise/api/GlobalExceptionControllerHandler.java
@@ -49,7 +49,7 @@ public class GlobalExceptionControllerHandler {
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ResponseBody
   public ErrorResponseDto handleHandlerMethodValidationException(HandlerMethodValidationException
-                                                         ex) {
+                                                                     ex) {
     return ErrorResponseDto.fromErrors(HttpStatus.BAD_REQUEST,
         HandlerMethodValidationException.class.getSimpleName(),
         "Validation failed for the input fields. Please check the data format and try again.",
@@ -57,13 +57,17 @@ public class GlobalExceptionControllerHandler {
             .map(error -> {
               if (error instanceof FieldError fieldError) {
                 return new ErrorResponseDto.Error(
+                    fieldError.getClass().getSimpleName(),
+                    fieldError.getDefaultMessage(),
                     fieldError.getField(),
-                    fieldError.getDefaultMessage()
-              );
+                    "field"
+                );
               }
               return new ErrorResponseDto.Error(
                   error.getClass().getSimpleName(),
-                  error.getDefaultMessage()
+                  error.getDefaultMessage(),
+                  null,
+                  null
               );
             })
             .toList());
@@ -85,8 +89,11 @@ public class GlobalExceptionControllerHandler {
         "Validation failed for the input fields. Please check the data format and try again.",
         ex.getBindingResult().getFieldErrors().stream()
             .map(error -> new ErrorResponseDto.Error(
-                error.getField(),
-                error.getDefaultMessage())
+                    error.getClass().getSimpleName(),
+                    error.getDefaultMessage(),
+                    error.getField(),
+                    "field"
+                )
             )
             .toList());
   }
@@ -110,7 +117,7 @@ public class GlobalExceptionControllerHandler {
     return ErrorResponseDto.fromErrors(
         HttpStatus.BAD_REQUEST,
         message,
-        List.of(new ErrorResponseDto.Error(ex.getClass().getSimpleName(), message))
+        List.of(new ErrorResponseDto.Error(ex.getClass().getSimpleName(), message, null, null))
     );
   }
 
@@ -138,7 +145,7 @@ public class GlobalExceptionControllerHandler {
     return ErrorResponseDto.fromErrors(
         HttpStatus.BAD_REQUEST,
         message,
-        List.of(new ErrorResponseDto.Error(ex.getClass().getSimpleName(), message))
+        List.of(new ErrorResponseDto.Error(ex.getClass().getSimpleName(), message, null, null))
     );
   }
 

--- a/src/main/java/com/elsevier/technicalexercise/api/GlobalExceptionControllerHandler.java
+++ b/src/main/java/com/elsevier/technicalexercise/api/GlobalExceptionControllerHandler.java
@@ -34,7 +34,6 @@ public class GlobalExceptionControllerHandler {
   public ResponseEntity<ErrorResponseDto> handleErrorResponseException(ErrorResponseException ex) {
     return new ResponseEntity<>(ErrorResponseDto.fromException(
         HttpStatus.valueOf(ex.getStatusCode().value()),
-        ex.getMessage(),
         ex
     ), ex.getStatusCode());
   }
@@ -56,19 +55,15 @@ public class GlobalExceptionControllerHandler {
         ex.getAllErrors().stream()
             .map(error -> {
               if (error instanceof FieldError fieldError) {
-                return new ErrorResponseDto.Error(
+                return new ErrorResponseDto.ErrorDetail(
                     fieldError.getClass().getSimpleName(),
                     fieldError.getDefaultMessage(),
                     fieldError.getField(),
                     "field"
                 );
               }
-              return new ErrorResponseDto.Error(
-                  error.getClass().getSimpleName(),
-                  error.getDefaultMessage(),
-                  null,
-                  null
-              );
+              return ErrorResponseDto.ErrorDetail.fromException(error.getClass().getSimpleName(),
+                  error.getDefaultMessage());
             })
             .toList());
   }
@@ -88,7 +83,7 @@ public class GlobalExceptionControllerHandler {
         MethodArgumentNotValidException.class.getSimpleName(),
         "Validation failed for the input fields. Please check the data format and try again.",
         ex.getBindingResult().getFieldErrors().stream()
-            .map(error -> new ErrorResponseDto.Error(
+            .map(error -> new ErrorResponseDto.ErrorDetail(
                     error.getClass().getSimpleName(),
                     error.getDefaultMessage(),
                     error.getField(),
@@ -117,7 +112,7 @@ public class GlobalExceptionControllerHandler {
     return ErrorResponseDto.fromErrors(
         HttpStatus.BAD_REQUEST,
         message,
-        List.of(new ErrorResponseDto.Error(ex.getClass().getSimpleName(), message, null, null))
+        List.of(ErrorResponseDto.ErrorDetail.fromException(ex, message))
     );
   }
 
@@ -145,7 +140,7 @@ public class GlobalExceptionControllerHandler {
     return ErrorResponseDto.fromErrors(
         HttpStatus.BAD_REQUEST,
         message,
-        List.of(new ErrorResponseDto.Error(ex.getClass().getSimpleName(), message, null, null))
+        List.of(ErrorResponseDto.ErrorDetail.fromException(ex.getClass().getSimpleName(), message))
     );
   }
 
@@ -165,7 +160,6 @@ public class GlobalExceptionControllerHandler {
 
     return ErrorResponseDto.fromException(
         HttpStatus.INTERNAL_SERVER_ERROR,
-        ex.getMessage(),
         ex
     );
   }
@@ -184,7 +178,6 @@ public class GlobalExceptionControllerHandler {
                                                          WebRequest request) {
     return ErrorResponseDto.fromException(
         HttpStatus.NOT_FOUND,
-        ex.getMessage(),
         ex
     );
   }

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ElementController.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ElementController.java
@@ -97,7 +97,6 @@ class ElementController {
   @ResponseBody
   public ErrorResponseDto handleValidationExceptions(PatchElementSizeException ex) {
     return ErrorResponseDto.fromException(HttpStatus.BAD_REQUEST,
-        PatchElementSizeException.class.getSimpleName(),
         ex);
   }
 
@@ -107,7 +106,6 @@ class ElementController {
   public ErrorResponseDto handleElementNotFoundException(
       PeriodicTableService.ElementNotFoundException ex) {
     return ErrorResponseDto.fromException(HttpStatus.NOT_FOUND,
-        PeriodicTableService.ElementNotFoundException.class.getSimpleName(),
         ex);
   }
 }

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ElementController.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ElementController.java
@@ -2,10 +2,12 @@ package com.elsevier.technicalexercise.periodictable;
 
 import com.elsevier.technicalexercise.api.ErrorResponseDto;
 import com.elsevier.technicalexercise.api.SuccessResponseDto;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,6 +46,7 @@ class ElementController {
   @GetMapping("/elements")
   @ResponseBody
   public CompletableFuture<SuccessResponseDto<SuccessResponseDto.Items<ElementDto>>> findElements(
+      @ParameterObject
       @Valid @ModelAttribute
       ElementListingRequestDto elementListingRequestDto) {
 

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ElementListingRequestDto.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ElementListingRequestDto.java
@@ -1,15 +1,16 @@
 package com.elsevier.technicalexercise.periodictable;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Data Transfer Object for element listing requests.
  * Contains filtering parameters for querying periodic table elements.
  */
+@Schema(description = "Data Transfer Object for element listing requests")
 public class ElementListingRequestDto {
-  @Parameter(
-      description = "The periodic table group to filter by."
-          + "Valid values are 1 to 18 (inclusive) or 'n/a'.",
+  @Schema(description = "The periodic table group to filter by. "
+      + "Valid values are 1 to 18 (inclusive) or 'n/a'.",
       example = "2"
   )
   @ValidGroup

--- a/src/main/java/com/elsevier/technicalexercise/periodictable/ElementPatchRequestDto.java
+++ b/src/main/java/com/elsevier/technicalexercise/periodictable/ElementPatchRequestDto.java
@@ -15,6 +15,9 @@ public class ElementPatchRequestDto {
 
   @NotNull(message = "Atomic number must not be null")
   @Positive(message = "Atomic number must be a positive integer")
+  @Schema(description = "Atomic number",
+      example = "3"
+  )
   private Integer atomicNumber;
 
   private String alternativeName;

--- a/src/test/java/com/elsevier/technicalexercise/periodictable/ElementControllerMutationTest.java
+++ b/src/test/java/com/elsevier/technicalexercise/periodictable/ElementControllerMutationTest.java
@@ -229,7 +229,7 @@ public class ElementControllerMutationTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.error.code").value(400))
             .andExpect(jsonPath("$.error.reason").value("PatchElementSizeException"))
-            .andExpect(jsonPath("$.error.message").value("PatchElementSizeException"));
+            .andExpect(jsonPath("$.error.message").value("Validation failed, Element must minimum 1 field to update"));
   }
 
   @Test


### PR DESCRIPTION
this close #36
Updated `ErrorResponseDto` to standardize error structure by adding `location` and `locationType` fields. Refined the exception handling logic in `GlobalExceptionControllerHandler` for better error detail mapping. Enhanced API request classes and methods with Swagger annotations for improved documentation and clarity.